### PR TITLE
Feature/cms integration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,9 @@ import path from 'path';
 export default defineConfig({
   site: 'https://independent-arts.org',
   integrations: [sitemap()],
+  image: {
+    domains: ["utfs.io"],
+  },
   vite: {
     resolve: {
       alias: {

--- a/src/components/NewsCard.astro
+++ b/src/components/NewsCard.astro
@@ -26,7 +26,7 @@ const external = attribution ? true : false;
 
 <a class='news' href={link} target={target}>
   <div class='imgContainer' aria-hidden='true'>
-    <Image src={coverImage} alt={title} width={350} height={200} />
+    <Image src={coverImage} alt={title} inferSize />
   </div>
   <div class='newsExcerptDetails'>
     <p>{formattedDate} - {nameToDisplay}</p>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -41,8 +41,7 @@ const articleSEO = {
         <Image
           src={entry.data.coverImage}
           alt={entry.data.title}
-          width={700}
-          height={400}
+          inferSize
         />
       </div>
       <h1 class='newsHeaderTitle'>{entry.data.title}</h1>
@@ -70,6 +69,7 @@ const articleSEO = {
   .newsHeaderImage > img {
     width: 100%;
     height: 100%;
+    min-height: 400px;
     object-fit: cover;
   }
   .newsHeaderTitle {


### PR DESCRIPTION
- Updated astro.config.mjs to specify allowed domains for remote image processing ` image: {
    domains: ["utfs.io"],
  },`
  
 - used `inferSize` on the `Image` component instead of passing a fixed width and height to allow Astro determine image dimensions for best quality