### PR TITLE
Update schema for newsPost

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   site: 'https://independent-arts.org',
   integrations: [sitemap()],
   image: {
-    domains: ["utfs.io"],
+    domains: ["utfs.io", "images.marblecms.com"],
   },
   vite: {
     resolve: {

--- a/src/components/NewsCard.astro
+++ b/src/components/NewsCard.astro
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const { data } = Astro.props;
-const { title, slug, attribution, author, publishedAt, coverImage } = data;
+const { title, slug, attribution, authors, publishedAt, coverImage } = data;
 
 const formattedDate = new Date(publishedAt)
   .toLocaleDateString('en-US', {
@@ -20,7 +20,7 @@ const formattedDate = new Date(publishedAt)
 
 const link = attribution ? attribution.url : `/news/${slug}`;
 const target = attribution ? '_blank' : '_self';
-const nameToDisplay = attribution ? attribution.author : author.name;
+const nameToDisplay = attribution ? attribution.author : authors[0].name;
 const external = attribution ? true : false;
 ---
 

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -48,7 +48,7 @@ const articleSEO = {
       </div>
       <h1 class='newsHeaderTitle'>{entry.data.title}</h1>
       <div class='newsHeaderDetails'>
-        <p>{entry.data.author.name} ・ {formattedDate}</p>
+        <p>{entry.data.authors[0].name} ・ {formattedDate}</p>
       </div>
     </div>
     <div class='l-container newsContentContainer'>

--- a/src/schemas/news.ts
+++ b/src/schemas/news.ts
@@ -8,10 +8,13 @@ export const newsPostSchema = z.object({
   description: z.string(),
   coverImage: z.string().url(),
   publishedAt: z.coerce.date(),
-  author: z.object({
-    name: z.string(),
-    image: z.string().url(),
-  }),
+  authors: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      image: z.string().url(),
+    })
+  ),
   category: z.object({
     id: z.string(),
     name: z.string(),


### PR DESCRIPTION
- This pr updates the type definitions for marblecms API response on a post as it now allows multiple authors per post
- It also updates the astro config to include the marblecms static asset domain to the allowed domains for image processing